### PR TITLE
Add backwards compatibility with pip v9

### DIFF
--- a/bin/license_finder_pip.py
+++ b/bin/license_finder_pip.py
@@ -2,8 +2,16 @@
 
 import json
 import sys
-from pip._internal.req import parse_requirements
-from pip._internal.download import PipSession
+
+try:
+        from pip._internal.req import parse_requirements
+except ImportError:
+        from pip.req import parse_requirements
+try:
+        from pip._internal.download import PipSession
+except ImportError:
+        from pip.download import PipSession
+
 from pip._vendor import pkg_resources
 from pip._vendor.six import print_
 


### PR DESCRIPTION
Version 5.2.0 made a breaking change by dropping support for pip version 9. This adds back that support while still supporting pip version 10.