### PR TITLE
Add an all caps version of the 'LICENCE' spelling as a candidate file

### DIFF
--- a/lib/license_finder/package_utils/license_files.rb
+++ b/lib/license_finder/package_utils/license_files.rb
@@ -2,7 +2,7 @@ require 'license_finder/package_utils/possible_license_file'
 
 module LicenseFinder
   class LicenseFiles
-    CANDIDATE_FILE_NAMES = %w[LICENSE License Licence COPYING README Readme ReadMe].freeze
+    CANDIDATE_FILE_NAMES = %w[LICENSE License LICENCE Licence COPYING README Readme ReadMe].freeze
     CANDIDATE_PATH_WILDCARD = "*{#{CANDIDATE_FILE_NAMES.join(',')}}*".freeze
 
     def self.find(install_path, options = {})

--- a/spec/fixtures/license_names/LICENCE.md
+++ b/spec/fixtures/license_names/LICENCE.md
@@ -1,0 +1,1 @@
+The MIT License

--- a/spec/lib/license_finder/packages/license_files_spec.rb
+++ b/spec/lib/license_finder/packages/license_files_spec.rb
@@ -23,7 +23,7 @@ module LicenseFinder
 
       it 'includes files with names like LICENSE, README or COPYING' do
         expect(files_in('license_names')).to match_array(
-          %w[COPYING.txt LICENSE Mit-License README.rdoc Licence.rdoc]
+          %w[COPYING.txt LICENSE LICENCE.md Mit-License README.rdoc Licence.rdoc]
         )
       end
 


### PR DESCRIPTION
This comes up for example in [vue-form-wizard](https://github.com/cristijora/vue-form-wizard)