### PR TITLE
improve mix license finder

### DIFF
--- a/features/features/package_managers/mix_spec.rb
+++ b/features/features/package_managers/mix_spec.rb
@@ -12,8 +12,9 @@ describe 'Mix Dependencies' do
     LicenseFinder::TestingDSL::MixProject.create
     puts 'mix project created'
     elixir_developer.run_license_finder
-    expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, ISC'
+    expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, MIT'
     expect(elixir_developer).to be_seeing_line 'uuid, 1.1.5, "Apache 2.0"'
+    expect(elixir_developer).to be_seeing_line 'plug, 1.7.2, "Apache 2.0"'
   end
 
   specify 'do not include in_umbrella: true dependencies internal to an umbrella project' do
@@ -21,7 +22,8 @@ describe 'Mix Dependencies' do
     puts 'mix umbrella project created'
     elixir_developer.run_license_finder
     expect(elixir_developer).not_to be_seeing_something_like /awesome/
-    expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, ISC'
+    expect(elixir_developer).to be_seeing_line 'fs, 0.9.1, MIT'
     expect(elixir_developer).to be_seeing_line 'uuid, 1.1.5, "Apache 2.0"'
+    expect(elixir_developer).to be_seeing_line 'plug, 1.7.2, "Apache 2.0"'
   end
 end

--- a/features/fixtures/mix.exs
+++ b/features/fixtures/mix.exs
@@ -17,6 +17,7 @@ defmodule Awesome.Mixfile do
 
   defp deps do
     [{:fs, "0.9.1"},
-     {:uuid, "1.1.5"}]
+     {:uuid, "1.1.5"},
+     {:plug, "1.7.2"}]
   end
 end

--- a/features/fixtures/mix_umbrella/apps/awesomer/mix.exs
+++ b/features/fixtures/mix_umbrella/apps/awesomer/mix.exs
@@ -26,7 +26,8 @@ defmodule Awesomer.MixProject do
   defp deps do
     [
       {:awesome, in_umbrella: true},
-      {:uuid, "1.1.5"}
+      {:uuid, "1.1.5"},
+      {:plug, "1.7.2"}
     ]
   end
 end

--- a/lib/license_finder/package_managers/mix.rb
+++ b/lib/license_finder/package_managers/mix.rb
@@ -7,16 +7,26 @@ module LicenseFinder
       @command = options[:mix_command] || Mix.package_management_command
       @deps_path = Pathname(options[:mix_deps_dir] || 'deps')
     end
-
     def current_packages
       mix_output.map do |name, version|
         MixPackage.new(
           name,
           version,
           install_path: @deps_path.join(name),
-          logger: logger
+          logger: logger,
+          spec_licenses: licenses(name)
         )
       end
+    end
+
+    # Adapted from licenser: https://github.com/unnawut/licensir/blob/71f96f8734adc73c0651050bd9f0e20ff52c61a8/lib/licensir/scanner.ex#L61
+    def licenses(name)
+      config_path = @deps_path.join(name).join("hex_metadata.config")
+      args = "\\\"#{config_path}\\\" |> :file.consult() |> case do {:ok, metadata} -> metadata; {:error, _} -> [] end |> List.keyfind(\\\"licenses\\\", 0) |> case do {_, licenses} -> licenses; _ -> [] end |> Enum.join(\\\"\\t\\\") |> IO.puts()"
+      command = "#{@command} run --no-start --no-compile -e \"#{args}\""
+      stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
+      raise "Command '#{command}' failed to execute: #{stderr}" unless status.success?
+      stdout.strip.split("\t")
     end
 
     def self.package_management_command

--- a/lib/license_finder/package_managers/mix.rb
+++ b/lib/license_finder/package_managers/mix.rb
@@ -7,6 +7,7 @@ module LicenseFinder
       @command = options[:mix_command] || Mix.package_management_command
       @deps_path = Pathname(options[:mix_deps_dir] || 'deps')
     end
+
     def current_packages
       mix_output.map do |name, version|
         MixPackage.new(
@@ -21,11 +22,14 @@ module LicenseFinder
 
     # Adapted from licenser: https://github.com/unnawut/licensir/blob/71f96f8734adc73c0651050bd9f0e20ff52c61a8/lib/licensir/scanner.ex#L61
     def licenses(name)
-      config_path = @deps_path.join(name).join("hex_metadata.config")
+      config_path = @deps_path.join(name).join('hex_metadata.config')
+      # rubocop:disable Metrics/LineLength
       args = "\\\"#{config_path}\\\" |> :file.consult() |> case do {:ok, metadata} -> metadata; {:error, _} -> [] end |> List.keyfind(\\\"licenses\\\", 0) |> case do {_, licenses} -> licenses; _ -> [] end |> Enum.join(\\\"\\t\\\") |> IO.puts()"
+      # rubocop:enable Metrics/LineLength
       command = "#{@command} run --no-start --no-compile -e \"#{args}\""
       stdout, stderr, status = Dir.chdir(project_path) { Cmd.run(command) }
       raise "Command '#{command}' failed to execute: #{stderr}" unless status.success?
+
       stdout.strip.split("\t")
     end
 

--- a/spec/lib/license_finder/package_managers/mix_spec.rb
+++ b/spec/lib/license_finder/package_managers/mix_spec.rb
@@ -47,6 +47,7 @@ module LicenseFinder
 
       it 'lists all the current packages' do
         allow(SharedHelpers::Cmd).to receive(:run).with('mix deps').and_return([output, '', cmd_success])
+        allow(SharedHelpers::Cmd).to receive(:run).with(/mix run --no-start --no-compile -e/).and_return(['MIT', '', cmd_success])
 
         current_packages = subject.current_packages
         expect(current_packages.map(&:name)).to eq(['fs', 'gettext', 'uuid-refknown', 'uuid'])


### PR DESCRIPTION
See issue: https://github.com/pivotal-legacy/LicenseFinder/issues/465
The discrepancy is due to licensir using [hex_metadata.config](https://github.com/unnawut/licensir/commit/71f96f8734adc73c0651050bd9f0e20ff52c61a8#diff-34329e6990ab0e1009ebd961c46ce120R62) and LicenseFinder only checking for a license file. However, not all packages include this file (plug for instance does not). But Hex [requires](https://hex.pm/docs/publish) the package includes a license config. This code grabs that preferentially.