### PR TITLE
Syncs Rubocop CI task with bundled version

### DIFF
--- a/ci/scripts/run-rubocop.sh
+++ b/ci/scripts/run-rubocop.sh
@@ -1,8 +1,11 @@
 #!/bin/bash -e
 
 cd LicenseFinder
-gem install rubocop --version 0.59.2
 
+bundle install --without runtime default
+
+version=`cat Gemfile.lock | grep '    rubocop' | awk -F'[\(*\)]' '{print $2}'`
+gem install rubocop --version $version
 
 echo "Running Rubocop ..."
 /usr/local/bundle/bin/rubocop


### PR DESCRIPTION
There is still a chance that there might be minor experience mismatches
due to the timeliness of a bundle, but this shouldn't happen often at
all.