### PR TITLE
Restore bundler fix for vendored gems

### DIFF
--- a/ci/scripts/run-tests.sh
+++ b/ci/scripts/run-tests.sh
@@ -19,6 +19,6 @@ pushd "$PROJECT_ROOT"
 
   bundle exec rake install
   bundle exec rake spec
-  bundle exec rake features
 
+  bundle exec rake features
 popd

--- a/features/features/configure/set_project_path_spec.rb
+++ b/features/features/configure/set_project_path_spec.rb
@@ -16,4 +16,10 @@ describe 'Project path' do
     developer.execute_command_outside_project("license_finder --quiet --project_path #{project.project_dir}")
     expect(developer).to be_seeing 'mitlicensed_dep, 1.2.3, MIT'
   end
+
+  specify 'works with vendored bundle and a project_path' do
+    project = LicenseFinder::TestingDSL::VendorBundlerProject.create
+    developer.execute_command_outside_project("license_finder --quiet --project_path #{project.project_dir}")
+    expect(developer).to be_seeing_line 'rake, 12.3.0, MIT'
+  end
 end

--- a/features/features/package_managers/bundler_spec.rb
+++ b/features/features/package_managers/bundler_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative '../../support/feature_helper'
+require_relative '../../../lib/license_finder/version'
+
+describe 'Bundler Dependencies' do
+  let(:bundler_developer) { LicenseFinder::TestingDSL::User.new }
+
+  specify 'are shown in reports' do
+    LicenseFinder::TestingDSL::BundlerProject.create
+    puts 'bundler project created'
+    bundler_developer.run_license_finder
+    expect(bundler_developer).to be_seeing_line "license_finder, #{LicenseFinder::VERSION}, MIT"
+  end
+
+  specify 'works with vendored bundle' do
+    LicenseFinder::TestingDSL::VendorBundlerProject.create
+    puts 'bundler project created'
+    bundler_developer.run_license_finder
+    expect(bundler_developer).to be_seeing_line 'rake, 12.3.0, MIT'
+  end
+end

--- a/lib/license_finder/package_managers/bundler.rb
+++ b/lib/license_finder/package_managers/bundler.rb
@@ -37,6 +37,9 @@ module LicenseFinder
 
     def definition
       # DI
+      ENV['BUNDLE_PATH'] = project_path.to_s
+      ENV['BUNDLE_GEMFILE'] = "#{project_path}/Gemfile"
+
       @definition ||= ::Bundler::Definition.build(detected_package_path, lockfile_path, nil)
     end
 
@@ -52,6 +55,8 @@ module LicenseFinder
 
       # clear gem paths before runninng specs_for
       Gem.clear_paths
+      ::Bundler.reset!
+      ::Bundler.configure
       @gem_details = definition.specs_for(included_groups)
     end
 


### PR DESCRIPTION
This reverts commit 98b2bb85b858d639d9b938dbe183b96d52164486.

Reverts previous reverts:
Revert "Fixes bundler env configuration for vendored gems" (commit: 6b9d1ea6c8b782547f0ad45cfeb9d4cf8b500602)
Revert "fix when `bundle install --path` option is used" (commit: 8c4e677ca28ecf9ef66f722413b7fc046f24b145)