### PR TITLE
Upgrade rubocop to 0.68.1 and adds rubocop-performance 1.0.0

### DIFF
--- a/ci/scripts/run-rubocop.sh
+++ b/ci/scripts/run-rubocop.sh
@@ -4,8 +4,11 @@ cd LicenseFinder
 
 bundle install --without runtime default
 
-version=`cat Gemfile.lock | grep '    rubocop' | awk -F'[\(*\)]' '{print $2}'`
-gem install rubocop --version $version
+rubocop_version=`cat Gemfile.lock | grep '    rubocop' | awk -F'[\(*\)]' '{print $2;exit}'`
+rubocop_performance_version=`cat Gemfile.lock | grep '    rubocop-performance' | awk -F'[\(*\)]' '{print $2;exit}'`
+
+gem install rubocop --version $rubocop_version
+gem install rubocop-performance --version $rubocop_performance_version
 
 echo "Running Rubocop ..."
-/usr/local/bundle/bin/rubocop
+/usr/local/bundle/bin/rubocop --require rubocop-performance

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -59,7 +59,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'rubocop', '~> 0.67.2'
+  s.add_development_dependency 'rubocop', '~> 0.68.1'
+  s.add_development_dependency 'rubocop-performance', '~> 1.0.0'
   s.add_development_dependency 'webmock', '~> 3.5'
 
   # to preserve ruby < 2.2.2 support.

--- a/license_finder.gemspec
+++ b/license_finder.gemspec
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'rubocop', '~> 0.68.1'
+  s.add_development_dependency 'rubocop', '~> 0.69.0'
   s.add_development_dependency 'rubocop-performance', '~> 1.0.0'
   s.add_development_dependency 'webmock', '~> 3.5'
 


### PR DESCRIPTION
This should have the same result. The extra gem is because this rubocop-performance functionality was extracted from the main gem and needed to be added back in. More info is in https://github.com/rubocop-hq/rubocop/issues/5977